### PR TITLE
feat: add permission control with admin panel

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { usePermissionStore } from "../store/permission";
+
+export default function AdminPage() {
+  const {
+    role,
+    setRole,
+    resources,
+    knowledgeBases,
+    addResource,
+    removeResource,
+    addKnowledgeBase,
+    removeKnowledgeBase,
+  } = usePermissionStore();
+
+  const [resInput, setResInput] = useState("");
+  const [kbInput, setKbInput] = useState("");
+
+  if (role !== "admin") {
+    return (
+      <div>
+        Access denied.{" "}
+        <button onClick={() => setRole("admin")}>Become admin</button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Admin Panel</h1>
+      <section>
+        <h2>Member Role</h2>
+        <select value={role} onChange={(e) => setRole(e.target.value as any)}>
+          <option value="admin">admin</option>
+          <option value="member">member</option>
+        </select>
+      </section>
+      <section>
+        <h2>Resources</h2>
+        <ul>
+          {resources.map((r) => (
+            <li key={r}>
+              {r} <button onClick={() => removeResource(r)}>remove</button>
+            </li>
+          ))}
+        </ul>
+        <input
+          value={resInput}
+          onChange={(e) => setResInput(e.target.value)}
+          placeholder="resource id"
+        />
+        <button
+          onClick={() => {
+            addResource(resInput);
+            setResInput("");
+          }}
+        >
+          add
+        </button>
+      </section>
+      <section>
+        <h2>Knowledge Bases</h2>
+        <ul>
+          {knowledgeBases.map((k) => (
+            <li key={k}>
+              {k} <button onClick={() => removeKnowledgeBase(k)}>remove</button>
+            </li>
+          ))}
+        </ul>
+        <input
+          value={kbInput}
+          onChange={(e) => setKbInput(e.target.value)}
+          placeholder="knowledge id"
+        />
+        <button
+          onClick={() => {
+            addKnowledgeBase(kbInput);
+            setKbInput("");
+          }}
+        >
+          add
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/app/components/PermissionGuard.tsx
+++ b/app/components/PermissionGuard.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { ReactNode } from "react";
+import { usePermissionStore } from "../store/permission";
+
+export function PermissionGuard({
+  kind,
+  id,
+  children,
+}: {
+  kind: "resource" | "knowledge";
+  id: string;
+  children: ReactNode;
+}) {
+  const { role, resources, knowledgeBases } = usePermissionStore();
+  const list = kind === "resource" ? resources : knowledgeBases;
+
+  if (role !== "admin" && !list.includes(id)) {
+    return <div>Access denied</div>;
+  }
+
+  return <>{children}</>;
+}

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -92,6 +92,7 @@ export enum StoreKey {
   Sync = "sync",
   SdList = "sd-list",
   Mcp = "mcp-store",
+  Permission = "permission-store",
 }
 
 export const DEFAULT_SIDEBAR_WIDTH = 300;

--- a/app/knowledge/page.tsx
+++ b/app/knowledge/page.tsx
@@ -1,0 +1,9 @@
+import { PermissionGuard } from "../components/PermissionGuard";
+
+export default function KnowledgePage() {
+  return (
+    <PermissionGuard kind="knowledge" id="kb1">
+      <div>Knowledge Base Content</div>
+    </PermissionGuard>
+  );
+}

--- a/app/resource/page.tsx
+++ b/app/resource/page.tsx
@@ -1,0 +1,9 @@
+import { PermissionGuard } from "../components/PermissionGuard";
+
+export default function ResourcePage() {
+  return (
+    <PermissionGuard kind="resource" id="default">
+      <div>Protected Resource Content</div>
+    </PermissionGuard>
+  );
+}

--- a/app/store/permission.ts
+++ b/app/store/permission.ts
@@ -1,0 +1,47 @@
+import { StoreKey } from "../constant";
+import { createPersistStore } from "../utils/store";
+
+export type MemberRole = "admin" | "member";
+
+export interface PermissionState {
+  role: MemberRole;
+  resources: string[];
+  knowledgeBases: string[];
+}
+
+const DEFAULT_PERMISSION_STATE: PermissionState = {
+  role: "member",
+  resources: [],
+  knowledgeBases: [],
+};
+
+export const usePermissionStore = createPersistStore(
+  DEFAULT_PERMISSION_STATE,
+  (set, get) => ({
+    setRole(role: MemberRole) {
+      set({ role });
+    },
+    addResource(id: string) {
+      set({ resources: Array.from(new Set([...get().resources, id])) });
+    },
+    removeResource(id: string) {
+      set({ resources: get().resources.filter((r) => r !== id) });
+    },
+    addKnowledgeBase(id: string) {
+      set({
+        knowledgeBases: Array.from(new Set([...get().knowledgeBases, id])),
+      });
+    },
+    removeKnowledgeBase(id: string) {
+      set({
+        knowledgeBases: get().knowledgeBases.filter((k) => k !== id),
+      });
+    },
+  }),
+  {
+    name: StoreKey.Permission,
+    version: 1,
+  },
+);
+
+export type PermissionStore = ReturnType<typeof usePermissionStore>;

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -6,7 +6,6 @@ import { ServiceProvider } from "./constant";
 // import { fetch as tauriFetch, ResponseType } from "@tauri-apps/api/http";
 import { fetch as tauriStreamFetch } from "./utils/stream";
 import { VISION_MODEL_REGEXES, EXCLUDE_VISION_MODEL_REGEXES } from "./constant";
-import { useAccessStore } from "./store";
 import { ModelSize } from "./typing";
 
 export function trimTopic(topic: string) {
@@ -255,10 +254,14 @@ export function getMessageImages(message: RequestMessage): string[] {
 }
 
 export function isVisionModel(model: string) {
-  const visionModels = useAccessStore.getState().visionModels;
-  const envVisionModels = visionModels
-    ?.split(",")
-    .map((m) => m.trim());
+  let visionModels: string | undefined;
+  try {
+    const { useAccessStore } = require("./store/access");
+    visionModels = useAccessStore.getState().visionModels;
+  } catch {
+    visionModels = process.env.VISION_MODELS;
+  }
+  const envVisionModels = visionModels?.split(",").map((m) => m.trim());
   if (envVisionModels?.includes(model)) {
     return true;
   }


### PR DESCRIPTION
## Summary
- add persistence store for member, resource and knowledge base permissions
- create admin panel and permission guard components
- refactor vision model utility to work without store import

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68af1c1fcd10832dadf7605e468e13a3